### PR TITLE
Fix map rendering and found-location saving after Map Genie update

### DIFF
--- a/src/common/client.ts
+++ b/src/common/client.ts
@@ -14,6 +14,7 @@ export class Client {
 
   private interceptor?: AxiosInterceptor;
   private _key?: Key;
+  private mapDataXhrInstalled = false;
 
   public get isLoggedIn(): boolean {
     return !!this._key;
@@ -187,6 +188,143 @@ export class Client {
     listener: (e: CustomEvent<Client.EventMap[K]>) => void
   ) {
     this.et.removeEventListener(event, listener as EventListener);
+  }
+
+  /**
+   * Resolve the set of location ids that belong to a given map, from the
+   * Map Genie API. Used to scope the user's saved found-locations (which the
+   * backend stores per game, across all of that game's maps) down to a single
+   * map.
+   */
+  public async getMapLocationIds(mapId: number): Promise<Set<number>> {
+    const map = await this.mapgenie.fetchMap(mapId);
+    const ids = new Set<number>();
+    for (const group of map.groups ?? []) {
+      for (const category of group.categories ?? []) {
+        for (const location of category.locations ?? []) {
+          ids.add(location.id);
+        }
+      }
+    }
+    return ids;
+  }
+
+  /**
+   * Build the `/api/v1/user/map-data/{mapId}` response from FMG's own data, in
+   * the same shape Map Genie's server returns. map.js applies this on boot to
+   * window.user / window.mapData.
+   *
+   * The found locations are scoped to this map: the backend stores them per
+   * game (every map of the game), but the server's per-map endpoint only
+   * returns the ones on the requested map, and map.js counts whatever it gets.
+   * Without scoping, the "found" counter would include locations from the
+   * game's other maps (and historically other games too).
+   */
+  private async buildMapDataResponse(mapId: number) {
+    const data = await this.getData();
+
+    const mapLocationIds = await this.getMapLocationIds(mapId);
+    const locations: Record<number, true> = {};
+    for (const id of Object.keys(data.locations ?? {})) {
+      if (mapLocationIds.has(Number(id))) locations[Number(id)] = true;
+    }
+
+    return {
+      // map.js assigns this straight to window.user.locations and looks up
+      // found state as `locations[id]`, so it has to be a `{ [id]: true }` set,
+      // which is exactly how FMG stores it. Map Genie's own API returns the
+      // same shape. The empty `[]` we sometimes see from the server is just PHP
+      // encoding an empty associative array as a JSON array.
+      locations,
+      hasPro: true,
+      trackedCategoryIds: data.trackedCategoryIds ?? [],
+      suggestions: [],
+      presets: data.presets ?? [],
+      notes: (data.notes ?? []).filter((note) => note.map_id === mapId),
+      maxMarkedLocations: Number.MAX_SAFE_INTEGER,
+    };
+  }
+
+  /**
+   * On boot, map.js re-syncs the user's state with GET
+   * /api/v1/user/map-data/{mapId} and applies the response to window.user and
+   * window.mapData. If we leave it alone it gets back the server's free account
+   * data (hasPro:false, locations:[], maxMarkedLocations:200) and overwrites
+   * everything FMG injected, which wipes the found locations we loaded from the
+   * backend and re-locks the cap.
+   *
+   * The catch is that this request does not go through window.axios (the
+   * instance our AxiosInterceptor wraps). map.js uses its own bundled axios, so
+   * the axios interceptor never sees it. Both axios instances do end up going
+   * through XMLHttpRequest, so we intercept there instead and answer the request
+   * with FMG's own data. The marking PUT/DELETE still go through window.axios and
+   * are short-circuited by the AxiosInterceptor before they reach XHR, so they
+   * are not affected by this patch.
+   *
+   * The v2 extension (the `main` branch) handled the same re-sync by pinning the
+   * injected values with getter / no-op-setter property traps (FMG_Map's
+   * lockProUnlock there). We answer the request instead because it gives map.js
+   * a consistent view: what it reads back from window.user is exactly what it
+   * just applied. A property trap, on the other hand, lets map.js's internal
+   * state drift away from window.user, and the v3 React UI could end up looping
+   * on that. We still pin the two pro flags (hasPro and maxMarkedLocations) as a
+   * cheap fallback in setup(), see MapPage.lockProUnlock.
+   */
+  public installMapDataResyncInterceptor() {
+    if (this.mapDataXhrInstalled) return;
+    if (!this.isLoggedIn) return;
+    this.mapDataXhrInstalled = true;
+
+    const pathRe = /\/api\/v1\/user\/map-data\/(\d+)/;
+    const origOpen = XMLHttpRequest.prototype.open;
+    const origSend = XMLHttpRequest.prototype.send;
+    const build = (mapId: number) => this.buildMapDataResponse(mapId);
+
+    XMLHttpRequest.prototype.open = function (this: any, method: string, url: any) {
+      const match = String(url).match(pathRe);
+      this.__fmgMapId =
+        match && String(method).toUpperCase() === "GET" ? Number(match[1]) : null;
+      this.__fmgUrl = String(url);
+      return origOpen.apply(this, arguments as any);
+    };
+
+    XMLHttpRequest.prototype.send = function (this: any, body?: any) {
+      if (this.__fmgMapId == null) return origSend.apply(this, arguments as any);
+
+      const xhr = this;
+      build(xhr.__fmgMapId)
+        .then((data) => {
+          const text = JSON.stringify(data);
+          const def = (key: string, value: unknown) =>
+            Object.defineProperty(xhr, key, { configurable: true, get: () => value });
+
+          def("readyState", 4);
+          def("status", 200);
+          def("statusText", "OK");
+          def("responseText", text);
+          def(
+            "response",
+            xhr.responseType === "" || xhr.responseType === "text" ? text : data
+          );
+          def("responseURL", xhr.__fmgUrl);
+          xhr.getAllResponseHeaders = () => "content-type: application/json\r\n";
+          xhr.getResponseHeader = (h: string) =>
+            /content-type/i.test(h) ? "application/json" : null;
+
+          xhr.dispatchEvent(new Event("readystatechange"));
+          xhr.dispatchEvent(new Event("load"));
+          xhr.dispatchEvent(new Event("loadend"));
+        })
+        .catch((err) => {
+          logger.error(
+            "Failed to serve FMG map-data over XHR, falling back to server.",
+            err
+          );
+          try {
+            origSend.call(xhr, body);
+          } catch {}
+        });
+    };
   }
 
   private registerHandlers() {

--- a/src/contexts/page/pages/map/index.ts
+++ b/src/contexts/page/pages/map/index.ts
@@ -28,28 +28,50 @@ export class MapPage extends Page {
   }
 
   private async loadUserData() {
+    if (!window.user || !window.mapData) return;
+
     await this.client.migrate();
     const data = await this.client.getData();
 
-    const locationsById = Object.fromEntries(
-      window.mapData!.locations.map((loc) => [loc.id, loc])
-    );
+    // Be defensive about every field below. The page's map data and the
+    // backend response can both be partially populated (e.g. a fresh free
+    // account whose user.locations is null). A thrown TypeError here would leave
+    // window.user.locations unset, which makes map.js crash on boot ("Cannot
+    // convert undefined or null to object") and silently breaks marking.
+    const currentMapId = window.mapData.map?.id;
+
+    // Scope the saved found-locations to the current map. The backend stores
+    // them per game (across every map of the game), so they must be filtered to
+    // this map or the "found" counter leaks in locations from the game's other
+    // maps (and other games). The page used to embed window.mapData.locations
+    // we could filter against, but Map Genie now loads it dynamically for
+    // logged-in users (it's usually empty here), so we resolve the map's
+    // location ids from the API in that case.
+    const mapLocations = window.mapData.locations ?? [];
+    const mapLocationIds =
+      mapLocations.length > 0
+        ? new Set(mapLocations.map((loc) => loc.id))
+        : currentMapId != null
+          ? await this.client
+              .getMapLocationIds(currentMapId)
+              .catch(() => new Set<number>())
+          : new Set<number>();
 
     const filteredLocations = Object.fromEntries(
-      Object.keys(data.locations)
-        .filter((id) => !!locationsById[id])
+      Object.keys(data.locations ?? {})
+        .filter((id) => mapLocationIds.has(Number(id)))
         .map((id) => [id, true])
     );
 
-    const filteredNotes = data.notes.filter(
-      (note) => note.map_id === window.mapData!.map.id
+    const filteredNotes = (data.notes ?? []).filter(
+      (note) => note.map_id === currentMapId
     );
 
-    window.user!.locations = filteredLocations;
-    window.user!.trackedCategoryIds = data.trackedCategoryIds;
+    window.user.locations = filteredLocations;
+    window.user.trackedCategoryIds = data.trackedCategoryIds ?? [];
 
-    window.mapData!.notes = filteredNotes;
-    window.mapData!.presets = data.presets;
+    window.mapData.notes = filteredNotes;
+    window.mapData.presets = data.presets ?? [];
   }
 
   private async unlockMapLinks() {
@@ -144,6 +166,54 @@ export class MapPage extends Page {
     }
   }
 
+  /**
+   * Pin the two scalar pro flags so they survive Map Genie's map.js boot.
+   *
+   * After we re-inject the blocked map.js it boots and re-syncs the user from
+   * GET /api/v1/user/map-data/{mapId}. Most of that re-sync (found locations,
+   * tracked categories, notes, presets) is already handled by answering that
+   * request with FMG's data, see installMapDataResyncInterceptor in client.ts.
+   * The two flags below gate the pro behaviour and are cheap, read-mostly
+   * values, so we pin them here as well, as a safety net in case answering the
+   * map-data request ever falls back to the server:
+   *
+   *   window.user.hasPro                -> true      canMarkLocation() reads it
+   *                                                  live, false re-locks the cap
+   *                                                  and stops marking
+   *   window.mapData.maxMarkedLocations -> Infinity  removes the free-user cap
+   *
+   * They are defined as getters with a no-op setter so map.js's re-sync
+   * assignment is silently ignored. A plain read-only property would throw
+   * instead, because map.js runs in strict mode.
+   *
+   * Only these two scalars are pinned. We deliberately do not trap the data
+   * collections (locations, trackedCategoryIds, notes, presets): trapping those
+   * made the v3 React UI misbehave, so they are kept correct through the
+   * map-data interceptor instead.
+   */
+  private lockProUnlock() {
+    if (window.user) {
+      this.lockValue(window.user, "hasPro", true);
+    }
+
+    if (window.mapData) {
+      this.lockValue(window.mapData, "maxMarkedLocations", Infinity);
+    }
+  }
+
+  /**
+   * Define `obj[key]` as a getter that always returns `value`, with a no-op
+   * setter so a later assignment is silently ignored instead of throwing.
+   */
+  private lockValue(obj: object, key: PropertyKey, value: unknown) {
+    Object.defineProperty(obj, key, {
+      configurable: true,
+      enumerable: true,
+      get: () => value,
+      set: () => {},
+    });
+  }
+
   private async login() {
     await waitForProperty(window, "mapManager");
 
@@ -161,22 +231,32 @@ export class MapPage extends Page {
   public async start() {
     await waitForProperty(window, "mapData");
 
-    await this.setupUser();
+    // Enrich the page with pro data. Every step here is best-effort: a failure
+    // (e.g. the Map Genie data API rejecting a missing/expired X-Api-Secret)
+    // must only be logged, never thrown. Otherwise it would abort start()
+    // before activateBlockedMapgenieScript() re-injects the blocked map.js and
+    // the map would never render. On failure we fall back to the page's
+    // original map data.
+    try {
+      await this.setupUser();
 
-    // Load map data and heatmaps for pro maps and maps with heatmaps
-    await this.loadMapData();
-    await this.loadHeatmaps();
+      // Load map data and heatmaps for pro maps and maps with heatmaps
+      await this.loadMapData();
+      await this.loadHeatmaps();
 
-    // Overwrite some game config options
-    if (window.config) {
-      window.config.proOnlyMedia = false;
-      window.config.checklistEnabled = true;
-      window.config.presetsEnabled = true;
-      window.config.iconSizeToggleEnabled = true;
+      // Overwrite some game config options
+      if (window.config) {
+        window.config.proOnlyMedia = false;
+        window.config.checklistEnabled = true;
+        window.config.presetsEnabled = true;
+        window.config.iconSizeToggleEnabled = true;
+      }
+
+      // Unlock pro map links
+      await this.unlockMapLinks();
+    } catch (err) {
+      logger.error("Failed to set up pro map, loading map anyway.", err);
     }
-
-    // Unlock pro map links
-    await this.unlockMapLinks();
 
     if (!window.user) {
       await activateBlockedMapgenieScript("map");
@@ -189,17 +269,38 @@ export class MapPage extends Page {
       return;
     }
 
-    // Request persistend storage
-    await this.client.storageRequestPersist();
-
-    // Login client from map data
+    // Login client from map data. Kept outside the best-effort block below so
+    // the request interceptor can register its handlers even if loading the
+    // saved user data fails.
     this.client.loginFromMap();
 
-    // Load user data
-    await this.loadUserData();
+    // Best-effort: load the logged-in user's saved data. Like the block above
+    // this must never abort start() before map.js is re-injected.
+    try {
+      // Request persistend storage
+      await this.client.storageRequestPersist();
 
-    // Fix alt map sdk if needed
-    this.fixAltMapSdk();
+      // Load user data
+      await this.loadUserData();
+
+      // Fix alt map sdk if needed
+      this.fixAltMapSdk();
+    } catch (err) {
+      logger.error("Failed to load user map data, loading map anyway.", err);
+    }
+
+    // Pin the pro flags right before map.js boots, so its boot-time re-sync
+    // (GET /api/v1/user/map-data/{mapId}) can't flip hasPro back to false and
+    // re-lock the free-user cap. Without this, map.js treats the user as free
+    // and stops sending mark/track requests, so nothing gets saved.
+    this.lockProUnlock();
+
+    // Answer map.js's boot re-sync (GET /api/v1/user/map-data/{mapId}) at the
+    // XMLHttpRequest layer with FMG's data, so it re-applies our found locations
+    // and pro state instead of the server's free-account data. map.js makes this
+    // request through its own bundled axios rather than window.axios, so the
+    // AxiosInterceptor cannot see it. That is why this hooks at the XHR level.
+    this.client.installMapDataResyncInterceptor();
 
     await activateBlockedMapgenieScript("map");
 


### PR DESCRIPTION
## What this fixes

After Map Genie's recent update the v3 extension stopped working on pro maps. Depending on the account, the map either did not render at all, or it rendered but found locations were never saved and never came back after a reload. The found counter also ended up mixing locations from different maps and games.

This tracks that down to four separate problems and fixes each one. It is based on HicH987's v2.1.1 fix (#105), reworked for the v3 architecture.

## The problems and the fixes

**1. The map did not render.**
`loadMapData()` and `loadUserData()` can now throw, for example when the data API rejects a missing or expired `X-Api-Secret`. Because they run inside `start()` before the blocked `map.js` is re-injected, a throw aborted setup and the map never loaded. Both steps are now best-effort: a failure is logged and we fall back to the page's own data, so `map.js` always gets re-injected.

**2. `loadUserData()` threw on free accounts.**
It assumed several fields were always present and threw a `TypeError` on a fresh account, which left `window.user.locations` unset and made `map.js` crash on boot with "Cannot convert undefined or null to object". Every field is now read defensively.

**3. Saved found locations were filtered out.**
Map Genie no longer embeds the map's locations in the page for logged-in users, it loads them dynamically after our setup runs. The old per-map filter ran against that (now empty) list and dropped every saved location, so nothing showed up on reload. We now resolve the map's location ids from the API and filter against those. As a side effect this also keeps the found counter scoped to the current map, instead of counting locations from the game's other maps (and from other games, since the backend stores found locations per game).

**4. map.js wiped everything on boot.**
On boot, `map.js` re-syncs the user from `GET /api/v1/user/map-data/{mapId}` and applies the response straight onto `window.user` and `window.mapData`. For a free account that response is `hasPro:false`, `locations:[]`, `maxMarkedLocations:200`, so it overwrote everything FMG injected: found locations gone, cap back, pro re-locked.

The tricky part is that this request does not go through `window.axios`, the instance the existing `AxiosInterceptor` wraps. `map.js` uses its own bundled axios, so the interceptor never saw it. Both axios instances still end up going through `XMLHttpRequest`, so this answers the request at that layer with FMG's own data (the found locations from the backend, scoped to the map, plus `hasPro` and the lifted cap). The marking PUT and DELETE keep going through `window.axios` and are short-circuited before they reach XHR, so they are untouched.

The v2 extension solved the same re-sync by pinning the injected values with getter and no-op-setter property traps (`lockProUnlock` on `main`). This answers the request instead, because it gives `map.js` a consistent view: what it reads back is exactly what it just applied. Trapping the collections let map.js's state drift away from `window.user`, and the v3 React UI could loop on that. `hasPro` and `maxMarkedLocations` are still pinned as a cheap fallback.

## Files changed

- `src/contexts/page/pages/map/index.ts`: best-effort setup, a defensive and map-scoped `loadUserData`, the scalar pin, and wiring up the re-sync answer.
- `src/common/client.ts`: building the map-data response from FMG's data, scoping found locations to a single map, and the XHR-level interceptor.

## Testing

Checked on a real logged-in account on rdr2map.com:

- The map renders.
- Marking a location saves it, and it is still marked after a reload.
- The found counter only counts the current map. A location marked on another map does not leak into it.
- No error flood, `hasPro` stays true.
- Logged-out (anonymous) pages still load with no new errors.
