### PR TITLE
Remember which categories are shown or hidden

### DIFF
--- a/src/common/storage/databases/dexie/index.ts
+++ b/src/common/storage/databases/dexie/index.ts
@@ -22,6 +22,10 @@ export class DexieDatabase implements Database {
     return this.repositories.categories;
   }
 
+  public get categoryFilters() {
+    return this.repositories.categoryFilters;
+  }
+
   public get presets() {
     return this.repositories.presets;
   }

--- a/src/common/storage/databases/dexie/repositories/categoryFilters.ts
+++ b/src/common/storage/databases/dexie/repositories/categoryFilters.ts
@@ -1,0 +1,56 @@
+import { AbstractRepository } from "./abstract";
+
+import type { Key } from "../../../key";
+
+export interface CategoryFilterModelV1 {
+  game_id: number;
+  user_id: number;
+  id: number;
+  visible: boolean;
+}
+
+/**
+ * Stores whether each category is shown or hidden in the sidebar, per game and
+ * user. Unlike `categories` (which tracks the pro "tracked categories"), this is
+ * the plain show/hide filter state, which Map Genie no longer persists itself.
+ */
+export class CategoryFiltersRepositoryV1 extends AbstractRepository<
+  CategoryFilterModelV1,
+  [number, number]
+> {
+  public readonly tableName = "categoryFilters";
+  public readonly index = "[id+user_id], [game_id+user_id], user_id";
+
+  public async has(key: Key) {
+    return this.table
+      .where({ game_id: key.gameId, user_id: key.userId })
+      .count()
+      .then((count) => count > 0);
+  }
+
+  public async get(key: Key): Promise<Record<number, boolean>> {
+    return this.table
+      .where({ game_id: key.gameId, user_id: key.userId })
+      .toArray()
+      .then((rows) => Object.fromEntries(rows.map((row) => [row.id, row.visible])));
+  }
+
+  public async set(key: Key, filters: Record<number, boolean>) {
+    await this.dexie.transaction("rw", this.table, async () => {
+      await this.clear(key);
+      const rows = Object.entries(filters).map(([id, visible]) => ({
+        game_id: key.gameId,
+        user_id: key.userId,
+        id: Number(id),
+        visible,
+      }));
+      if (rows.length > 0) await this.table.bulkAdd(rows);
+    });
+  }
+
+  public async clear(key: Key) {
+    await this.table
+      .where({ game_id: key.gameId, user_id: key.userId })
+      .delete();
+  }
+}

--- a/src/common/storage/databases/dexie/repositories/index.ts
+++ b/src/common/storage/databases/dexie/repositories/index.ts
@@ -2,6 +2,7 @@ import { Dexie } from "dexie";
 
 import { LocationsRepositoryV1 } from "./locations";
 import { CategoriesRepositoryV1 } from "./categories";
+import { CategoryFiltersRepositoryV1 } from "./categoryFilters";
 import { PresetsRepositoryV1 } from "./presets";
 import { PresetsOrderingRepositoryV1 } from "./presetsOrdering";
 import { NotesRepositoryV1 } from "./notes";
@@ -11,6 +12,7 @@ import { ProfilesRepositoryV1 } from "./profiles";
 export {
   LocationsRepositoryV1,
   CategoriesRepositoryV1,
+  CategoryFiltersRepositoryV1,
   PresetsRepositoryV1,
   PresetsOrderingRepositoryV1,
   NotesRepositoryV1,
@@ -20,6 +22,7 @@ export {
 
 export type { LocationModelV1 } from "./locations";
 export type { CategoryModelV1 } from "./categories";
+export type { CategoryFilterModelV1 } from "./categoryFilters";
 export type { PresetModelV1 } from "./presets";
 export type { PresetOrderModelV1 } from "./presetsOrdering";
 export type { NoteModelV1 } from "./notes";
@@ -31,6 +34,7 @@ export class Repositories {
 
   public readonly locations: LocationsRepositoryV1;
   public readonly categories: CategoriesRepositoryV1;
+  public readonly categoryFilters: CategoryFiltersRepositoryV1;
   public readonly presets: PresetsRepositoryV1;
   public readonly presetsOrdering: PresetsOrderingRepositoryV1;
   public readonly notes: NotesRepositoryV1;
@@ -42,6 +46,7 @@ export class Repositories {
 
     this.locations = new LocationsRepositoryV1(dexie);
     this.categories = new CategoriesRepositoryV1(dexie);
+    this.categoryFilters = new CategoryFiltersRepositoryV1(dexie);
     this.presets = new PresetsRepositoryV1(dexie);
     this.presetsOrdering = new PresetsOrderingRepositoryV1(dexie);
     this.notes = new NotesRepositoryV1(dexie);
@@ -60,6 +65,12 @@ export class Repositories {
       notes: this.notes.index,
       bookmarks: this.bookmarks.index,
       profiles: this.profiles.index,
+    });
+
+    // v2 adds the category show/hide filter store. Existing stores are
+    // unchanged, so Dexie just creates the new one and keeps all current data.
+    this.dexie.version(2).stores({
+      categoryFilters: this.categoryFilters.index,
     });
   }
 }

--- a/src/contexts/page/pages/map/ui/components/Settings/customSettings/index.ts
+++ b/src/contexts/page/pages/map/ui/components/Settings/customSettings/index.ts
@@ -2,6 +2,7 @@ import { RememberFoundLocationsShownSetting } from "./settings/rememberFoundLoca
 import { RememberMapTypeSetting } from "./settings/rememberMapLayout";
 import { RememberToggleInteriorsOverlaySetting } from "./settings/rememberToggleInteriorsOverlay";
 import { RememberTagFiltersSetting } from "./settings/rememberTagFilters";
+import { RememberCategoryFiltersSetting } from "./settings/rememberCategoryFilters";
 
 import type { CustomSetting } from "./customSetting";
 
@@ -14,6 +15,8 @@ export class CustomSettings {
   public readonly rememberToggleInteriorsOverlay =
     new RememberToggleInteriorsOverlaySetting();
   public readonly rememberTagFilters = new RememberTagFiltersSetting();
+  public readonly rememberCategoryFilters =
+    new RememberCategoryFiltersSetting();
 
   public get all(): CustomSetting[] {
     return Object.values(this);

--- a/src/contexts/page/pages/map/ui/components/Settings/customSettings/settings/rememberCategoryFilters.ts
+++ b/src/contexts/page/pages/map/ui/components/Settings/customSettings/settings/rememberCategoryFilters.ts
@@ -1,0 +1,201 @@
+import { CustomSetting } from "../customSetting";
+
+import { Key } from "@/common/storage";
+import backendService from "@/services/backend.service";
+
+/**
+ * Remembers which categories are shown or hidden in the left sidebar, per game
+ * and user. The state is kept in the Dexie backend, next to the rest of the
+ * user's data, so it survives reloads and stays with the profile.
+ *
+ * Map Genie used to persist this itself (it wrote localStorage keys like
+ * `mg:settings:game_X:visible_categories:id_Y`, which the v2 extension picked up
+ * with a storage filter). The current Map Genie dropped that: toggling a
+ * category is now purely client-side, it sends no request and writes nothing, so
+ * the state is lost on every reload. This brings the behaviour back.
+ *
+ * A toggle has no network or storage side effect to hook, and the sidebar
+ * button only carries a `category-visible` / `category-hidden` class, so:
+ *   - to save, we listen for clicks on the sidebar (delegated on the document,
+ *     because map.js re-renders the list and a listener bound to it would stop
+ *     working) and read the classes back a moment later, and
+ *   - to restore, we click the buttons whose state differs from what we saved.
+ *
+ * It is always on. There is nothing to opt into, it just restores something Map
+ * Genie used to do on its own.
+ */
+export class RememberCategoryFiltersSetting extends CustomSetting {
+  public readonly label = "Remember Category Filters";
+
+  private readonly backend = backendService.use();
+
+  private saveTimer?: ReturnType<typeof setTimeout>;
+  private applyTimer?: ReturnType<typeof setInterval>;
+
+  // Stays true while we apply the saved state on load, so those programmatic
+  // clicks don't get saved back as if the user made them.
+  private applying = true;
+
+  public get enabled(): boolean {
+    return true;
+  }
+
+  public get applicable(): boolean {
+    return !!window.user && this.categoryButtons().length > 0;
+  }
+
+  private categoryButtons(): HTMLButtonElement[] {
+    return Array.from(
+      document.querySelectorAll<HTMLButtonElement>("#categories .category-item")
+    );
+  }
+
+  private categoryId(button: HTMLElement): number | null {
+    const match = button.id.match(/category-item-(\d+)/);
+    return match ? Number(match[1]) : null;
+  }
+
+  /**
+   * Whether a category is shown. Returns null while the button has neither class
+   * yet (it is still rendering), so we don't act on an unsettled state.
+   */
+  private isVisible(button: HTMLElement): boolean | null {
+    if (button.classList.contains("category-visible")) return true;
+    if (button.classList.contains("category-hidden")) return false;
+    return null;
+  }
+
+  /** Read the current shown/hidden state of every settled category. */
+  private readState(): Record<number, boolean> {
+    const state: Record<number, boolean> = {};
+    for (const button of this.categoryButtons()) {
+      const id = this.categoryId(button);
+      const visible = this.isVisible(button);
+      if (id !== null && visible !== null) state[id] = visible;
+    }
+    return state;
+  }
+
+  /** Click the categories whose state differs from `saved`. Idempotent. */
+  private applySaved(saved: Record<number, boolean>): number {
+    let clicks = 0;
+    for (const button of this.categoryButtons()) {
+      const id = this.categoryId(button);
+      if (id === null) continue;
+
+      const wanted = saved[id];
+      const current = this.isVisible(button);
+      if (wanted === undefined || current === null) continue;
+
+      if (current !== wanted) {
+        button.click();
+        clicks++;
+      }
+    }
+    return clicks;
+  }
+
+  /** Stop applying the saved state. Called once the user takes over. */
+  private stopApplying(): void {
+    if (this.applyTimer) {
+      clearInterval(this.applyTimer);
+      this.applyTimer = undefined;
+    }
+    this.applying = false;
+  }
+
+  private save(): void {
+    if (this.applying || !window.user) return;
+    clearTimeout(this.saveTimer);
+    // Coalesce the burst of clicks a group toggle produces.
+    this.saveTimer = setTimeout(() => {
+      this.backend
+        .setCategoryFilters(Key.fromWindow(), this.readState())
+        .catch((error) => logger.warn("Failed to save category filters", error));
+    }, 300);
+  }
+
+  /** Wait until map.js has rendered the category sidebar. */
+  private async waitForCategories(): Promise<void> {
+    const start = Date.now();
+    while (this.categoryButtons().length === 0 && Date.now() - start < 30000) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+
+  public async init(): Promise<void> {
+    // Poll the DOM for the sidebar instead of the base waitForMapLoaded() helper.
+    // That helper waits for the map's "load" event, which never fires if the map
+    // already loaded by the time we listen, and would hang init forever. We only
+    // need the category buttons here anyway.
+    await this.waitForCategories();
+
+    // Settings are constructed before FMG fills in window.user, but by the time
+    // the categories have rendered it is set (or the user is anonymous).
+    if (!window.user) return; // nothing to remember for anonymous users
+
+    document.addEventListener(
+      "click",
+      (event) => {
+        const target = event.target as HTMLElement | null;
+        if (target?.closest?.("#categories button")) {
+          // The user is now in control, so stop re-applying the saved state and
+          // save what they do instead. Let map.js flip the class before we read.
+          this.stopApplying();
+          setTimeout(() => this.save(), 250);
+        }
+      },
+      true
+    );
+  }
+
+  public async load(): Promise<void> {
+    if (!window.user) {
+      this.applying = false;
+      return;
+    }
+
+    const saved = await this.backend
+      .getCategoryFilters(Key.fromWindow())
+      .catch(() => null);
+
+    if (!saved || Object.keys(saved).length === 0) {
+      this.applying = false;
+      return;
+    }
+
+    // Categories render in batches and map.js re-renders the list, so a single
+    // pass can miss buttons that aren't there yet (this matters most for
+    // categories hidden by default, which we need to click open). Re-apply (it
+    // is idempotent) until the sidebar both stops growing and needs no more
+    // changes, then start saving the user's own toggles. stopApplying() also
+    // runs as soon as the user clicks something, so we never fight them.
+    const start = Date.now();
+    let lastCount = -1;
+    let stable = 0;
+    this.applyTimer = setInterval(() => {
+      const count = this.categoryButtons().length;
+      const clicks = this.applySaved(saved);
+
+      if (count === lastCount && clicks === 0) stable++;
+      else stable = 0;
+      lastCount = count;
+
+      if (stable >= 3 || Date.now() - start > 20000) {
+        this.stopApplying();
+      }
+    }, 400);
+    this.applySaved(saved);
+  }
+
+  protected enable(): void {
+    this.applying = false;
+    this.save();
+  }
+
+  protected disable(): void {
+    if (window.user) {
+      this.backend.setCategoryFilters(Key.fromWindow(), {}).catch(() => {});
+    }
+  }
+}

--- a/src/services/backend.service.ts
+++ b/src/services/backend.service.ts
@@ -119,6 +119,14 @@ class BackendService {
     await this.database.categories.setTracked(key, categoryId, track);
   }
 
+  public async getCategoryFilters(key: Key) {
+    return this.database.categoryFilters.get(key);
+  }
+
+  public async setCategoryFilters(key: Key, filters: Record<number, boolean>) {
+    await this.database.categoryFilters.set(key, filters);
+  }
+
   public async addNote(key: Key, note: Omit<MG.Note, "id" | "created_at">) {
     const created_at = new Date().toISOString();
     const id = await this.database.notes.add(key, { ...note, created_at });


### PR DESCRIPTION
## What this adds

Map Genie used to remember the sidebar category filters (which categories you show or hide) across reloads, and the v2 extension persisted them too. The current Map Genie dropped that: toggling a category is now purely client-side, it sends no request and writes nothing, so the state resets on every reload.

This restores it. The show/hide state is saved in the Dexie backend, next to the rest of the user's data, so it survives reloads and stays with the profile.

## How it works

A category toggle has no network request or storage write to intercept, and the sidebar button only carries a `category-visible` or `category-hidden` class. So:

- To save: the setting listens for clicks on the sidebar. The listener is delegated on the document, because map.js re-renders the category list and a listener bound to the list would stop firing. After a click it reads the classes back and stores the full state.
- To restore: on load it reads the saved state and clicks the buttons whose state differs. Categories render in batches (including ones hidden by default, which have to be clicked open) and map.js re-renders the list, so it keeps re-applying (the apply is idempotent) until the sidebar stops changing. It stops the moment the user clicks something, so it never fights them.

It is always on, like the behaviour Map Genie used to have. There is no toggle to flip.

## Storage

- A new `categoryFilters` Dexie store, added in schema version 2. The upgrade only adds the store, existing data is left untouched.
- `getCategoryFilters` and `setCategoryFilters` on the backend service. The setting forwards to the backend, which does the actual write, so the page script is not saving directly.

## Files

- `src/common/storage/databases/dexie/repositories/categoryFilters.ts` (new store)
- `src/common/storage/databases/dexie/repositories/index.ts` (register it and add schema v2)
- `src/common/storage/databases/dexie/index.ts` (accessor)
- `src/services/backend.service.ts` (get and set methods)
- `src/contexts/page/pages/map/ui/components/Settings/customSettings/settings/rememberCategoryFilters.ts` (the setting)
- `src/contexts/page/pages/map/ui/components/Settings/customSettings/index.ts` (register the setting)

## Testing

Checked on a real logged-in account on rdr2map.com:

- Hide a category, reload, it stays hidden. Show it again, reload, it stays shown.
- Hide a whole group such as Collectibles, reload, all of it stays hidden. Show the whole group, reload, everything comes back visible, including the categories that are hidden by default.
- Anonymous pages are left alone (it does nothing without a logged-in user).

## Note

This builds on the Dexie backend, so it needs a logged-in user with the map working. On the current v3 the map does not render for logged-in users until #106 is merged, so this is easiest to try with that applied.
