### PR TITLE
fix: mapgenie v3 site compatibility — map/component loading

### DIFF
--- a/src/common/client.ts
+++ b/src/common/client.ts
@@ -14,7 +14,6 @@ export class Client {
 
   private interceptor?: AxiosInterceptor;
   private _key?: Key;
-  private mapDataXhrInstalled = false;
 
   public get isLoggedIn(): boolean {
     return !!this._key;
@@ -138,16 +137,20 @@ export class Client {
 
     // Fallback to fetching from API if not available in mapData
     if (!presets) {
-      const game = await this.mapgenie.fetchGame(this.key.gameId);
-      presets = game.default_presets;
+      try {
+        const game = await this.mapgenie.fetchGame(this.key.gameId);
+        presets = game.default_presets;
+      } catch (error) {
+        logger.debug("Could not fetch default presets.", error);
+        presets = [];
+      }
     }
 
     //Invert IDs to avoid conflicts with local saved presets
-    presets.forEach((preset) => {
-      preset.id = -preset.id;
-    });
-
-    return presets;
+    return presets.map((preset) => ({
+      ...preset,
+      id: -Math.abs(preset.id),
+    }));
   }
 
   public async getActiveUserId() {
@@ -188,143 +191,6 @@ export class Client {
     listener: (e: CustomEvent<Client.EventMap[K]>) => void
   ) {
     this.et.removeEventListener(event, listener as EventListener);
-  }
-
-  /**
-   * Resolve the set of location ids that belong to a given map, from the
-   * Map Genie API. Used to scope the user's saved found-locations (which the
-   * backend stores per game, across all of that game's maps) down to a single
-   * map.
-   */
-  public async getMapLocationIds(mapId: number): Promise<Set<number>> {
-    const map = await this.mapgenie.fetchMap(mapId);
-    const ids = new Set<number>();
-    for (const group of map.groups ?? []) {
-      for (const category of group.categories ?? []) {
-        for (const location of category.locations ?? []) {
-          ids.add(location.id);
-        }
-      }
-    }
-    return ids;
-  }
-
-  /**
-   * Build the `/api/v1/user/map-data/{mapId}` response from FMG's own data, in
-   * the same shape Map Genie's server returns. map.js applies this on boot to
-   * window.user / window.mapData.
-   *
-   * The found locations are scoped to this map: the backend stores them per
-   * game (every map of the game), but the server's per-map endpoint only
-   * returns the ones on the requested map, and map.js counts whatever it gets.
-   * Without scoping, the "found" counter would include locations from the
-   * game's other maps (and historically other games too).
-   */
-  private async buildMapDataResponse(mapId: number) {
-    const data = await this.getData();
-
-    const mapLocationIds = await this.getMapLocationIds(mapId);
-    const locations: Record<number, true> = {};
-    for (const id of Object.keys(data.locations ?? {})) {
-      if (mapLocationIds.has(Number(id))) locations[Number(id)] = true;
-    }
-
-    return {
-      // map.js assigns this straight to window.user.locations and looks up
-      // found state as `locations[id]`, so it has to be a `{ [id]: true }` set,
-      // which is exactly how FMG stores it. Map Genie's own API returns the
-      // same shape. The empty `[]` we sometimes see from the server is just PHP
-      // encoding an empty associative array as a JSON array.
-      locations,
-      hasPro: true,
-      trackedCategoryIds: data.trackedCategoryIds ?? [],
-      suggestions: [],
-      presets: data.presets ?? [],
-      notes: (data.notes ?? []).filter((note) => note.map_id === mapId),
-      maxMarkedLocations: Number.MAX_SAFE_INTEGER,
-    };
-  }
-
-  /**
-   * On boot, map.js re-syncs the user's state with GET
-   * /api/v1/user/map-data/{mapId} and applies the response to window.user and
-   * window.mapData. If we leave it alone it gets back the server's free account
-   * data (hasPro:false, locations:[], maxMarkedLocations:200) and overwrites
-   * everything FMG injected, which wipes the found locations we loaded from the
-   * backend and re-locks the cap.
-   *
-   * The catch is that this request does not go through window.axios (the
-   * instance our AxiosInterceptor wraps). map.js uses its own bundled axios, so
-   * the axios interceptor never sees it. Both axios instances do end up going
-   * through XMLHttpRequest, so we intercept there instead and answer the request
-   * with FMG's own data. The marking PUT/DELETE still go through window.axios and
-   * are short-circuited by the AxiosInterceptor before they reach XHR, so they
-   * are not affected by this patch.
-   *
-   * The v2 extension (the `main` branch) handled the same re-sync by pinning the
-   * injected values with getter / no-op-setter property traps (FMG_Map's
-   * lockProUnlock there). We answer the request instead because it gives map.js
-   * a consistent view: what it reads back from window.user is exactly what it
-   * just applied. A property trap, on the other hand, lets map.js's internal
-   * state drift away from window.user, and the v3 React UI could end up looping
-   * on that. We still pin the two pro flags (hasPro and maxMarkedLocations) as a
-   * cheap fallback in setup(), see MapPage.lockProUnlock.
-   */
-  public installMapDataResyncInterceptor() {
-    if (this.mapDataXhrInstalled) return;
-    if (!this.isLoggedIn) return;
-    this.mapDataXhrInstalled = true;
-
-    const pathRe = /\/api\/v1\/user\/map-data\/(\d+)/;
-    const origOpen = XMLHttpRequest.prototype.open;
-    const origSend = XMLHttpRequest.prototype.send;
-    const build = (mapId: number) => this.buildMapDataResponse(mapId);
-
-    XMLHttpRequest.prototype.open = function (this: any, method: string, url: any) {
-      const match = String(url).match(pathRe);
-      this.__fmgMapId =
-        match && String(method).toUpperCase() === "GET" ? Number(match[1]) : null;
-      this.__fmgUrl = String(url);
-      return origOpen.apply(this, arguments as any);
-    };
-
-    XMLHttpRequest.prototype.send = function (this: any, body?: any) {
-      if (this.__fmgMapId == null) return origSend.apply(this, arguments as any);
-
-      const xhr = this;
-      build(xhr.__fmgMapId)
-        .then((data) => {
-          const text = JSON.stringify(data);
-          const def = (key: string, value: unknown) =>
-            Object.defineProperty(xhr, key, { configurable: true, get: () => value });
-
-          def("readyState", 4);
-          def("status", 200);
-          def("statusText", "OK");
-          def("responseText", text);
-          def(
-            "response",
-            xhr.responseType === "" || xhr.responseType === "text" ? text : data
-          );
-          def("responseURL", xhr.__fmgUrl);
-          xhr.getAllResponseHeaders = () => "content-type: application/json\r\n";
-          xhr.getResponseHeader = (h: string) =>
-            /content-type/i.test(h) ? "application/json" : null;
-
-          xhr.dispatchEvent(new Event("readystatechange"));
-          xhr.dispatchEvent(new Event("load"));
-          xhr.dispatchEvent(new Event("loadend"));
-        })
-        .catch((err) => {
-          logger.error(
-            "Failed to serve FMG map-data over XHR, falling back to server.",
-            err
-          );
-          try {
-            origSend.call(xhr, body);
-          } catch {}
-        });
-    };
   }
 
   private registerHandlers() {

--- a/src/common/mapgenie/data.ts
+++ b/src/common/mapgenie/data.ts
@@ -26,11 +26,106 @@ const getCategories = (map: MG.Api.MapFull) => {
   );
 };
 
-export const loadMapData = (map: MG.Api.MapFullForGame) => {
+const xyPatternTilePaths = new Set([
+  "tarkov/lighthouse/dark-v10",
+  "tarkov/lighthouse/default-v10",
+  "tarkov/streets/default-v10",
+]);
+
+export const getTileCoordinateSwapStorageKey = (
+  gameId: number,
+  mapId: number
+) => `mg:settings:game_${gameId}:map_${mapId}:swap_tile_coordinates`;
+
+export const getStoredTileCoordinateSwap = (gameId: number, mapId: number) => {
+  try {
+    return (
+      JSON.parse(
+        localStorage.getItem(getTileCoordinateSwapStorageKey(gameId, mapId)) ??
+          "false"
+      ) === true
+    );
+  } catch {
+    return false;
+  }
+};
+
+const getFallbackTilePattern = (
+  path: string | undefined,
+  extension: string,
+  swapTileCoordinates = false
+) => {
+  const defaultOrder = path && xyPatternTilePaths.has(path) ? "xy" : "yx";
+  const order =
+    swapTileCoordinates ? (defaultOrder === "xy" ? "yx" : "xy") : defaultOrder;
+  const coordinates = order === "xy" ? "{x}/{y}" : "{y}/{x}";
+
+  return `${path}/{z}/${coordinates}.${extension}`;
+};
+
+const normalizeTileSet = (
+  tileSet: Partial<MG.TileSet>,
+  originalTileSet?: MG.TileSet,
+  { swapTileCoordinates = false }: NormalizeTileSetOptions = {}
+): MG.TileSet => {
+  const path = tileSet.path ?? originalTileSet?.path;
+  const extension = tileSet.extension ?? originalTileSet?.extension ?? "jpg";
+  const pattern =
+    tileSet.pattern ??
+    (originalTileSet?.path === path ? originalTileSet?.pattern : undefined) ??
+    getFallbackTilePattern(path, extension, swapTileCoordinates);
+
+  return {
+    ...originalTileSet,
+    ...tileSet,
+    pattern,
+  } as MG.TileSet;
+};
+
+interface NormalizeTileSetOptions {
+  swapTileCoordinates?: boolean;
+}
+
+const normalizeMapConfig = (
+  config: MG.Api.MapFull["config"],
+  originalConfig?: MG.MapConfig,
+  { swapTileCoordinates = false }: NormalizeMapConfigOptions = {}
+): MG.MapConfig => {
+  return {
+    ...config,
+    tile_sets: config.tile_sets.map((tileSet) => {
+      const originalTileSet = originalConfig?.tile_sets.find(
+        (original) => original.path === tileSet.path
+      );
+
+      return normalizeTileSet(tileSet, originalTileSet, {
+        swapTileCoordinates,
+      });
+    }),
+  };
+};
+
+interface NormalizeMapConfigOptions {
+  swapTileCoordinates?: boolean;
+}
+
+export interface LoadMapDataOptions {
+  preserveMapConfig?: boolean;
+  swapTileCoordinates?: boolean;
+}
+
+export const loadMapData = (
+  map: MG.Api.MapFull,
+  {
+    preserveMapConfig = false,
+    swapTileCoordinates = false,
+  }: LoadMapDataOptions = {}
+) => {
   if (!window.mapData) {
     throw new Error("mapData is not available on window");
   }
 
+  const originalMapConfig = window.mapData.mapConfig;
   const locations = getLocations(map);
   const categories = getCategories(map);
 
@@ -38,7 +133,11 @@ export const loadMapData = (map: MG.Api.MapFullForGame) => {
   window.mapData.groups = map.groups;
   window.mapData.locations = locations;
   window.mapData.categories = categories;
-  window.mapData.mapConfig = map.config;
+  window.mapData.mapConfig = preserveMapConfig
+    ? originalMapConfig
+    : normalizeMapConfig(map.config, originalMapConfig, {
+        swapTileCoordinates,
+      });
   window.mapData.regions = map.regions;
 
   window.initialZoom = map.config.initial_zoom;

--- a/src/common/mapgenie/index.ts
+++ b/src/common/mapgenie/index.ts
@@ -6,6 +6,14 @@ export * from "./page";
 export * from "./links";
 export * as mapDataUtils from "./data";
 
+const getReadyScriptUrl = (src: string) => {
+  const url = new URL(src, window.location.href);
+  if (!url.searchParams.has("ready")) {
+    url.search = url.search ? `?ready&${url.search.slice(1)}` : "?ready";
+  }
+  return url.toString();
+};
+
 /**
  * This function reloads a blocked mapgenie script.
  * The background script blocks certain mapgenie scripts from loading.
@@ -15,17 +23,31 @@ export * as mapDataUtils from "./data";
 export const activateBlockedMapgenieScript = async (name: string) => {
   await waitForBody();
 
-  const $ogScript = $(
+  const ogScript = document.querySelector<HTMLScriptElement>(
     `script[src^="https://cdn.mapgenie.io/js/${name}.js?id="]`
   );
 
-  if ($ogScript.length === 0) {
+  if (!ogScript) {
     return false;
   }
 
-  const src = $ogScript.attr("src")!.replace("id=", "ready&id=");
+  const src = getReadyScriptUrl(ogScript.src);
 
-  $(`<script/>`, { src }).appendTo("body");
+  await new Promise<void>((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = src;
+    script.async = false;
+    script.addEventListener("load", () => resolve(), { once: true });
+    script.addEventListener(
+      "error",
+      () => reject(new Error(`Failed to load MapGenie script: ${src}`)),
+      { once: true }
+    );
+
+    document.body.appendChild(script);
+  });
+
+  return true;
 };
 
 export const getAuthToken = () => {

--- a/src/common/mapgenie/links.ts
+++ b/src/common/mapgenie/links.ts
@@ -1,15 +1,30 @@
 import type mapgenieService from "@/services/mapgenie.service";
 
+type GameWithMaps = MG.Api.Game | MG.Api.GameFull;
+type MapInfo = MG.Api.Map | MG.Api.MapFullForGame | MG.Map;
+
 const getLinkMapName = ($link: JQuery<HTMLAnchorElement>) => {
   return $link
     .text()
-    .replace(/\[(WIP|PRO)\]/, "")
+    .replace(/\s*\[(WIP|PRO)\]\s*/gi, " ")
+    .replace(/\s+/g, " ")
     .trim();
+};
+
+const isLockedMapLink = (link: HTMLAnchorElement) => {
+  const href = link.getAttribute("href")?.trim();
+  if (!href || href === "#") return true;
+
+  try {
+    return new URL(link.href).pathname.endsWith("/upgrade");
+  } catch {
+    return link.href.endsWith("/upgrade");
+  }
 };
 
 const getProLinks = ($links: JQuery<HTMLAnchorElement>) => {
   return $links.filter(function () {
-    return this.href.endsWith("/upgrade");
+    return isLockedMapLink(this);
   });
 };
 
@@ -26,13 +41,32 @@ const getProHeaderLinks = (
   });
 };
 
-const createMapByTitle = (game: MG.Api.GameFull) => {
-  return Object.fromEntries(game.maps.map((m) => [m.title.trim(), m]));
+const createMapByTitle = (maps: MapInfo[]) => {
+  return Object.fromEntries(maps.map((m) => [m.title.trim(), m]));
+};
+
+const getFreeLinkUrl = (
+  $links: JQuery<HTMLAnchorElement>,
+  game: GameWithMaps
+) => {
+  const freeLink = $links.toArray().find((link) => !isLockedMapLink(link));
+  if (freeLink) {
+    return new URL(freeLink.href);
+  }
+
+  const freeMap = game.maps.find((map) => !map.premium && map.available);
+  const fallbackMap = freeMap ?? game.maps.find((map) => !map.premium);
+
+  if (!fallbackMap) {
+    return null;
+  }
+
+  return new URL(`${game.config.url}/maps/${fallbackMap.slug}`);
 };
 
 const fixLink = (
   link: HTMLAnchorElement,
-  mapByTitle: Record<string, MG.Api.MapFull>,
+  mapByTitle: Record<string, MapInfo>,
   freeUrl: URL
 ) => {
   const $link = $(link);
@@ -77,19 +111,21 @@ export const fixMapLinks = async (mapgenie: mapgenieService.Instance) => {
     $("a.map-link.selected").toggleClass("selected", false);
   }
 
-  // Get game for this map
-  const game = await mapgenie.fetchGame(window.game!.id);
+  const currentMapId = window.mapData?.map.id;
+  const game = currentMapId
+    ? (await mapgenie.fetchMap(currentMapId)).game
+    : await mapgenie.fetchGameInfo(window.game!.id);
 
-  // Get first free map we find
-  const freeMap = game.maps.find((map) => !map.premium);
-
-  if (!freeMap) {
+  const freeMapUrl = getFreeLinkUrl($sidebarLinks, game);
+  if (!freeMapUrl) {
     logger.warn("No free map found, can not unlock map selector panel.");
     return;
   }
 
-  const freeMapUrl = new URL(freeMap.url);
-  const mapByTitle = createMapByTitle(game);
+  const mapByTitle = createMapByTitle([
+    ...game.maps,
+    ...(window.mapData?.maps ?? []),
+  ]);
 
   $proSidebarLinks.each((_, link) => fixLink(link, mapByTitle, freeMapUrl));
   $proHeaderLinks.each((_, link) => fixLink(link, mapByTitle, freeMapUrl));
@@ -106,16 +142,13 @@ export const fixGameHomeLinks = async (mapgenie: mapgenieService.Instance) => {
   const [_, slug] = location.pathname.split("/");
   const game = await mapgenie.fetchGameBySlug(slug);
 
-  // Get first free map we find
-  const freeMap = game.maps.find((map) => !map.premium);
-
-  if (!freeMap) {
+  const freeMapUrl = getFreeLinkUrl($mapLinks, game);
+  if (!freeMapUrl) {
     logger.warn("No free map found, can not pro links in game home page.");
     return;
   }
 
-  const freeMapUrl = new URL(freeMap.url);
-  const mapByTitle = createMapByTitle(game);
+  const mapByTitle = createMapByTitle(game.maps);
 
   $proMapLinks.each((_, link) => fixLink(link, mapByTitle, freeMapUrl));
 };

--- a/src/common/mapgenie/page.ts
+++ b/src/common/mapgenie/page.ts
@@ -11,20 +11,29 @@ export type PageType =
 
 const isHomePage = () => {
   return (
-    window.location.host === "mapgenie.io" && window.location.pathname === "/"
+    ["mapgenie.io", "www.mapgenie.io"].includes(window.location.host) &&
+    window.location.pathname === "/"
   );
 };
 
-const hasMapgenieCndUrl = () => {
-  return $(`[href*="cdn.mapgenie.io"]`).length > 0;
+const hasMapgenieCdnUrl = () => {
+  return $(`[href*="cdn.mapgenie.io"],[src*="cdn.mapgenie.io"]`).length > 0;
 };
 
 const hasMapgeniePrebid = () => {
   return $(`[src$="mapgenie.prebid.js"]`).length > 0;
 };
 
+const hasMapgenieMeta = () => {
+  return (
+    $(`meta[name="base-url"][content*="mapgenie"]`).length > 0 ||
+    $(`meta[property="og:url"][content*="mapgenie"]`).length > 0 ||
+    $(`link[rel="canonical"][href*="mapgenie"]`).length > 0
+  );
+};
+
 const isMapgenieSite = () => {
-  return hasMapgenieCndUrl() || hasMapgeniePrebid();
+  return hasMapgenieCdnUrl() || hasMapgeniePrebid() || hasMapgenieMeta();
 };
 
 export const getPageType = async () => {

--- a/src/contexts/background/rules/index.ts
+++ b/src/contexts/background/rules/index.ts
@@ -6,6 +6,7 @@ import { WebRequestManager } from "./webRequest";
 
 export class Rules {
   private readonly manager: RulesManager = this.createManager();
+  private readonly blockedScriptRuleIds = [2, 3];
 
   constructor() {
     this.setupRules();
@@ -61,7 +62,7 @@ export class Rules {
       action: { type: "block" },
       condition: {
         requestDomains: ["cdn.mapgenie.io"],
-        urlFilter: "/js/map.js?id=*",
+        regexFilter: "^https://cdn\\.mapgenie\\.io/js/map\\.js\\?id=",
         resourceTypes: ["script"],
       },
     });
@@ -73,14 +74,16 @@ export class Rules {
       action: { type: "block" },
       condition: {
         requestDomains: ["cdn.mapgenie.io"],
-        urlFilter: "/js/TarkovQuestToolWidget.js?id=*",
+        regexFilter:
+          "^https://cdn\\.mapgenie\\.io/js/TarkovQuestToolWidget\\.js\\?id=",
         resourceTypes: ["script"],
       },
     });
   }
 
   public async enable() {
-    await this.manager.enable([1, 2, 3]);
+    await this.manager.disable([2, 3]);
+    await this.manager.enable([1, ...this.blockedScriptRuleIds]);
   }
 
   public disable() {

--- a/src/contexts/content/index.ts
+++ b/src/contexts/content/index.ts
@@ -6,6 +6,7 @@ import { getPageType } from "@/common/mapgenie";
 import { Popup } from "./ui/Popup";
 
 import extensionService from "@/services/extension.service";
+import backendService from "@/services/backend.service";
 import { contentLoggerService } from "@/services/logger.service";
 
 export default defineContentScript({
@@ -15,12 +16,18 @@ export default defineContentScript({
   async main() {
     const params = new URLSearchParams(window.location.search);
     if (params.has("fmgBackend")) return;
+    if (params.has("fmgStorage")) return;
 
     const page = await getPageType();
     if (page === "unknown") return;
 
     const extension = extensionService.provide();
     contentLoggerService.provide();
+
+    if (import.meta.env.FIREFOX && window.top === window) {
+      backendService.provide();
+      logger.log("Backend service provided from page content script.");
+    }
 
     const enabled = await ExtensionSettings.enabled.getValue();
     if (!enabled) {

--- a/src/contexts/page/index.ts
+++ b/src/contexts/page/index.ts
@@ -50,30 +50,46 @@ const checkReload = () => {
   }
 };
 
+const initializeBackendUserState = async (
+  backend: backendService.Instance
+) => {
+  try {
+    // Set auth token in backend service
+    const auth = getAuthToken();
+    await backend.setAuthToken(auth);
+    await backend.updateUser();
+  } catch (err) {
+    logger.debug(
+      "Could not refresh MapGenie account profile; continuing with local FMG data.",
+      err
+    );
+  }
+};
+
 export default defineUnlistedScript(async () => {
   const extension = extensionService.use();
-  const backend = backendService.use();
-
-  const pageType = await getPageType();
-  const pageScript = await getPageScript(pageType);
-
-  if (!pageScript) return;
-
-  // Set auth token in backend service
-  const auth = getAuthToken();
-  await backend.setAuthToken(auth);
-  await backend.updateUser();
-
-  // Reload if script was already injected
-  checkReload();
-
-  logger.log(`Initializing page ${pageType} script.`);
-
-  MapgenieAdBlocker.start();
-  MapgenieAdBlocker.removePrivacyPopup();
-
   let failed: boolean = false;
+  let pageType: PageType = "unknown";
+  let pageScript: Awaited<ReturnType<typeof getPageScript>> = null;
+
   try {
+    const backend = backendService.use();
+
+    pageType = await getPageType();
+    pageScript = await getPageScript(pageType);
+
+    if (!pageScript) return;
+
+    void initializeBackendUserState(backend);
+
+    // Reload if script was already injected
+    checkReload();
+
+    logger.log(`Initializing page ${pageType} script.`);
+
+    MapgenieAdBlocker.start();
+    MapgenieAdBlocker.removePrivacyPopup();
+
     await pageScript.start();
 
     logger.log(`Page ${pageType} script initialized.`);
@@ -85,5 +101,7 @@ export default defineUnlistedScript(async () => {
     await extension.unmountLoadingOverlay();
   }
 
-  pageService.provide({ failed, page: pageScript });
+  if (pageScript) {
+    pageService.provide({ failed, page: pageScript });
+  }
 });

--- a/src/contexts/page/pages/map/index.ts
+++ b/src/contexts/page/pages/map/index.ts
@@ -13,69 +13,250 @@ export class MapPage extends Page {
   private client = new Client();
   private ui = new UI();
 
+  private async withTimeout<T>(
+    promise: Promise<T>,
+    timeout: number,
+    message: string
+  ) {
+    let handle: number | undefined;
+
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+      handle = window.setTimeout(
+        () => reject(new Error(`${message} timed out after ${timeout}ms.`)),
+        timeout
+      );
+    });
+
+    try {
+      return await Promise.race([promise, timeoutPromise]);
+    } finally {
+      if (handle !== undefined) {
+        window.clearTimeout(handle);
+      }
+    }
+  }
+
   private async setupUser() {
-    if (!window.user) return;
+    const user = window.user;
+    if (!user) return;
 
-    // Get the active user from the backend
-    const activeUserId = await this.client.getActiveUserId();
-
-    // Update the user
-    window.user.realId = window.user.id;
-    window.user.id = activeUserId ?? window.user.id;
-    window.user!.hasPro = true;
+    user.realId = user.id;
+    window.isPro = true;
+    user.hasPro = true;
 
     window.mapData!.maxMarkedLocations = Infinity;
+
+    try {
+      const activeUserId = await this.withTimeout(
+        this.client.getActiveUserId(),
+        5000,
+        "Active FMG profile lookup"
+      );
+
+      user.id = activeUserId ?? user.id;
+    } catch (err) {
+      logger.warn("Could not load active FMG profile before map boot.", err);
+    }
+  }
+
+  private getTrackedCategoryIdsForCurrentMap(categoryIds: number[]) {
+    const categories = window.mapData?.categories ?? {};
+    const availableCategoryIds = new Set(
+      Object.keys(categories).map((id) => Number(id))
+    );
+
+    const filteredCategoryIds = categoryIds.filter((id) =>
+      availableCategoryIds.has(id)
+    );
+
+    if (filteredCategoryIds.length !== categoryIds.length) {
+      const ignoredCategoryIds = categoryIds.filter(
+        (id) => !availableCategoryIds.has(id)
+      );
+      logger.warn(
+        "Ignoring tracked categories that are not available on the current map.",
+        ignoredCategoryIds
+      );
+    }
+
+    return filteredCategoryIds;
+  }
+
+  private filterTrackedCategoriesForCurrentMap() {
+    if (!window.user) return;
+
+    window.user.trackedCategoryIds = this.getTrackedCategoryIdsForCurrentMap(
+      window.user.trackedCategoryIds ?? []
+    );
   }
 
   private async loadUserData() {
-    if (!window.user || !window.mapData) return;
-
     await this.client.migrate();
     const data = await this.client.getData();
 
-    // Be defensive about every field below. The page's map data and the
-    // backend response can both be partially populated (e.g. a fresh free
-    // account whose user.locations is null). A thrown TypeError here would leave
-    // window.user.locations unset, which makes map.js crash on boot ("Cannot
-    // convert undefined or null to object") and silently breaks marking.
-    const currentMapId = window.mapData.map?.id;
-
-    // Scope the saved found-locations to the current map. The backend stores
-    // them per game (across every map of the game), so they must be filtered to
-    // this map or the "found" counter leaks in locations from the game's other
-    // maps (and other games). The page used to embed window.mapData.locations
-    // we could filter against, but Map Genie now loads it dynamically for
-    // logged-in users (it's usually empty here), so we resolve the map's
-    // location ids from the API in that case.
-    const mapLocations = window.mapData.locations ?? [];
-    const mapLocationIds =
-      mapLocations.length > 0
-        ? new Set(mapLocations.map((loc) => loc.id))
-        : currentMapId != null
-          ? await this.client
-              .getMapLocationIds(currentMapId)
-              .catch(() => new Set<number>())
-          : new Set<number>();
-
-    const filteredLocations = Object.fromEntries(
-      Object.keys(data.locations ?? {})
-        .filter((id) => mapLocationIds.has(Number(id)))
-        .map((id) => [id, true])
+    const pageLocations = window.mapData!.locations ?? [];
+    const locationsById = Object.fromEntries(
+      pageLocations.map((loc) => [loc.id, loc])
     );
 
-    const filteredNotes = (data.notes ?? []).filter(
-      (note) => note.map_id === currentMapId
+    const filteredLocations =
+      pageLocations.length > 0
+        ? Object.fromEntries(
+            Object.keys(data.locations)
+              .filter((id) => !!locationsById[id])
+              .map((id) => [id, true])
+          )
+        : data.locations;
+
+    const filteredNotes = data.notes.filter(
+      (note) => note.map_id === window.mapData!.map.id
     );
 
-    window.user.locations = filteredLocations;
-    window.user.trackedCategoryIds = data.trackedCategoryIds ?? [];
+    window.user!.locations = filteredLocations;
+    window.user!.trackedCategoryIds = this.getTrackedCategoryIdsForCurrentMap(
+      data.trackedCategoryIds
+    );
 
-    window.mapData.notes = filteredNotes;
-    window.mapData.presets = data.presets ?? [];
+    window.mapData!.notes = filteredNotes;
+    window.mapData!.presets = data.presets;
+
+    logger.log(
+      `Loaded ${Object.keys(filteredLocations).length} saved FMG locations.`
+    );
+  }
+
+  private getSavedLocationIdsForCurrentMap() {
+    const user = window.user;
+    if (!user?.locations) return [];
+
+    const pageLocationIds = new Set(
+      (window.mapData?.locations ?? []).map((l) => l.id)
+    );
+
+    return Object.keys(user.locations)
+      .filter((id) => pageLocationIds.has(Number(id)))
+      .map(Number);
+  }
+
+  private async waitForMapObject(timeout = 5000) {
+    await waitForProperty(window, "mapManager");
+
+    const deadline = Date.now() + timeout;
+    while (!window.mapManager?.map && Date.now() < deadline) {
+      await new Promise((resolve) => window.setTimeout(resolve, 100));
+    }
+
+    return window.mapManager?.map ?? null;
+  }
+
+  private async waitForMapStyle(timeout = 5000) {
+    const map = await this.waitForMapObject(timeout);
+    if (!map) return;
+
+    if (typeof map.loaded === "function" && map.loaded()) {
+      return;
+    }
+
+    if (typeof map.on !== "function") {
+      return;
+    }
+
+    await this.withTimeout(
+      new Promise<void>((resolve) => {
+        map.on("load", () => resolve());
+        map.on("idle", () => resolve());
+      }),
+      timeout,
+      "Waiting for MapGenie map style"
+    ).catch((err) => {
+      logger.warn("Map style event did not arrive before timeout.", err);
+    });
+  }
+
+  private async updateFoundLocationsStyle() {
+    try {
+      window.mapManager?.updateFoundLocationsStyle();
+      return;
+    } catch (err) {
+      logger.warn(
+        "Could not update found location style immediately; retrying after map load.",
+        err
+      );
+    }
+
+    try {
+      await this.waitForMapStyle();
+      window.mapManager?.updateFoundLocationsStyle();
+    } catch (err) {
+      logger.warn("Could not update found location style after retry.", err);
+    }
+  }
+
+  private async syncSavedLocationsToMap() {
+    const store = window.store;
+    if (!store) return;
+
+    const locationIds = this.getSavedLocationIdsForCurrentMap();
+    if (locationIds.length === 0) return;
+
+    const state = store.getState();
+    const foundLocations = state.user.foundLocations ?? {};
+    const missingLocationIds = locationIds.filter(
+      (id) => !foundLocations[id]
+    );
+
+    if (missingLocationIds.length > 0) {
+      store.dispatch({
+        type: "MG:USER:MARK_LOCATIONS",
+        meta: {
+          locationIds: missingLocationIds,
+          found: true,
+        },
+      } as any);
+    }
+
+    await this.updateFoundLocationsStyle();
+
+    logger.log(
+      `Synced ${locationIds.length} saved FMG locations to the map` +
+        ` (${missingLocationIds.length} newly marked).`
+    );
+  }
+
+  private lockValue(obj: object, key: PropertyKey, value: unknown) {
+    Object.defineProperty(obj, key, {
+      configurable: true,
+      enumerable: true,
+      get: () => value,
+      set: () => {},
+    });
+  }
+
+  private lockProData() {
+    if (window.user) {
+      this.lockValue(window, "isPro", true);
+      this.lockValue(window.user, "hasPro", true);
+      this.lockValue(window.user, "locations", window.user.locations);
+      this.lockValue(
+        window.user,
+        "trackedCategoryIds",
+        window.user.trackedCategoryIds
+      );
+    }
+
+    if (window.mapData) {
+      this.lockValue(window.mapData, "maxMarkedLocations", Infinity);
+      this.lockValue(window.mapData, "notes", window.mapData.notes);
+      this.lockValue(window.mapData, "presets", window.mapData.presets);
+    }
   }
 
   private async unlockMapLinks() {
-    await fixMapLinks(this.client.mapgenie);
+    try {
+      await fixMapLinks(this.client.mapgenie);
+    } catch (err) {
+      logger.error("Failed to unlock map links, loading map anyway.", err);
+    }
   }
 
   @LazyGetter()
@@ -85,26 +266,15 @@ export class MapPage extends Page {
     return mapIdParmam ? Number(mapIdParmam) : null;
   }
 
-  @LazyGetter()
-  private get hasProCategoryLocations() {
-    const proCategoryLocationCounts = window.mapData!.proCategoryLocationCounts;
-    for (const key in proCategoryLocationCounts) {
-      const count = proCategoryLocationCounts[key];
-      if (count > 0) return true;
-    }
-    return false;
-  }
-
   private async loadMapDataForMapId(mapId: number) {
-    const game = await this.client.mapgenie.fetchGame(window.game!.id);
-    const map = game.maps.find((m) => m.id === mapId);
-
-    if (!map) {
-      logger.warn(`Map with ID ${mapId} not found in game ${game.title}`);
-      return;
-    }
-
-    mapDataUtils.loadMapData(map);
+    const map = await this.client.mapgenie.fetchMap(mapId);
+    mapDataUtils.loadMapData(map, {
+      preserveMapConfig: mapId === window.mapData?.map.id,
+      swapTileCoordinates: mapDataUtils.getStoredTileCoordinateSwap(
+        map.game_id,
+        map.id
+      ),
+    });
   }
 
   private async loadMapData() {
@@ -112,16 +282,12 @@ export class MapPage extends Page {
 
     if (this.fmgMapId !== null) {
       await this.loadMapDataForMapId(this.fmgMapId);
-      return;
-    }
-
-    if (this.hasProCategoryLocations) {
-      await this.loadMapDataForMapId(window.mapData!.map.id);
     }
   }
 
   private async loadHeatmaps() {
     if (!window.mapData?.heatmapGroups) return;
+    if (this.fmgMapId === null) return;
 
     const hasHeatmaps = window.mapData.heatmapGroups.length > 0;
     if (!hasHeatmaps) return;
@@ -131,6 +297,16 @@ export class MapPage extends Page {
     );
 
     mapDataUtils.loadHeatmaps(heatmaps);
+  }
+
+  private async loadRemoteMapData() {
+    try {
+      // If MapGenie's data API blocks a request, still boot the page's own map.
+      await this.loadMapData();
+      await this.loadHeatmaps();
+    } catch (err) {
+      logger.error("Failed to load pro map data, loading map anyway.", err);
+    }
   }
 
   private setupEventListeners() {
@@ -166,54 +342,6 @@ export class MapPage extends Page {
     }
   }
 
-  /**
-   * Pin the two scalar pro flags so they survive Map Genie's map.js boot.
-   *
-   * After we re-inject the blocked map.js it boots and re-syncs the user from
-   * GET /api/v1/user/map-data/{mapId}. Most of that re-sync (found locations,
-   * tracked categories, notes, presets) is already handled by answering that
-   * request with FMG's data, see installMapDataResyncInterceptor in client.ts.
-   * The two flags below gate the pro behaviour and are cheap, read-mostly
-   * values, so we pin them here as well, as a safety net in case answering the
-   * map-data request ever falls back to the server:
-   *
-   *   window.user.hasPro                -> true      canMarkLocation() reads it
-   *                                                  live, false re-locks the cap
-   *                                                  and stops marking
-   *   window.mapData.maxMarkedLocations -> Infinity  removes the free-user cap
-   *
-   * They are defined as getters with a no-op setter so map.js's re-sync
-   * assignment is silently ignored. A plain read-only property would throw
-   * instead, because map.js runs in strict mode.
-   *
-   * Only these two scalars are pinned. We deliberately do not trap the data
-   * collections (locations, trackedCategoryIds, notes, presets): trapping those
-   * made the v3 React UI misbehave, so they are kept correct through the
-   * map-data interceptor instead.
-   */
-  private lockProUnlock() {
-    if (window.user) {
-      this.lockValue(window.user, "hasPro", true);
-    }
-
-    if (window.mapData) {
-      this.lockValue(window.mapData, "maxMarkedLocations", Infinity);
-    }
-  }
-
-  /**
-   * Define `obj[key]` as a getter that always returns `value`, with a no-op
-   * setter so a later assignment is silently ignored instead of throwing.
-   */
-  private lockValue(obj: object, key: PropertyKey, value: unknown) {
-    Object.defineProperty(obj, key, {
-      configurable: true,
-      enumerable: true,
-      get: () => value,
-      set: () => {},
-    });
-  }
-
   private async login() {
     await waitForProperty(window, "mapManager");
 
@@ -228,38 +356,55 @@ export class MapPage extends Page {
     }
   }
 
+  private async activateMapScript() {
+    if (window.mapManager) return;
+
+    const activated = await activateBlockedMapgenieScript("map");
+    if (!activated) {
+      logger.warn("MapGenie map script not found.");
+      return;
+    }
+
+    await waitForProperty(window, "mapManager", 30000);
+  }
+
+  private async installRequestInterceptor() {
+    try {
+      await this.withTimeout(
+        this.client.installInterceptor(),
+        10000,
+        "FMG request interceptor installation"
+      );
+    } catch (err) {
+      logger.error("Failed to install FMG request interceptor.", err);
+    }
+  }
+
   public async start() {
     await waitForProperty(window, "mapData");
 
-    // Enrich the page with pro data. Every step here is best-effort: a failure
-    // (e.g. the Map Genie data API rejecting a missing/expired X-Api-Secret)
-    // must only be logged, never thrown. Otherwise it would abort start()
-    // before activateBlockedMapgenieScript() re-injects the blocked map.js and
-    // the map would never render. On failure we fall back to the page's
-    // original map data.
-    try {
-      await this.setupUser();
+    await this.setupUser();
 
-      // Load map data and heatmaps for pro maps and maps with heatmaps
-      await this.loadMapData();
-      await this.loadHeatmaps();
+    // Load map data and heatmaps for pro maps and maps with heatmaps
+    await this.loadRemoteMapData();
 
-      // Overwrite some game config options
-      if (window.config) {
-        window.config.proOnlyMedia = false;
-        window.config.checklistEnabled = true;
-        window.config.presetsEnabled = true;
-        window.config.iconSizeToggleEnabled = true;
-      }
+    // MapGenie stores tracked categories per game. Only pass categories that
+    // exist on this map or its map script may fail during initialization.
+    this.filterTrackedCategoriesForCurrentMap();
 
-      // Unlock pro map links
-      await this.unlockMapLinks();
-    } catch (err) {
-      logger.error("Failed to set up pro map, loading map anyway.", err);
+    // Overwrite some game config options
+    if (window.config) {
+      window.config.proOnlyMedia = false;
+      window.config.checklistEnabled = true;
+      window.config.presetsEnabled = true;
+      window.config.iconSizeToggleEnabled = true;
     }
 
+    // Unlock pro map links
+    await this.unlockMapLinks();
+
     if (!window.user) {
-      await activateBlockedMapgenieScript("map");
+      await this.activateMapScript();
 
       // In development mode, auto-login and load map data to speed up testing
       if (import.meta.env.DEV) {
@@ -269,43 +414,35 @@ export class MapPage extends Page {
       return;
     }
 
-    // Login client from map data. Kept outside the best-effort block below so
-    // the request interceptor can register its handlers even if loading the
-    // saved user data fails.
-    this.client.loginFromMap();
-
-    // Best-effort: load the logged-in user's saved data. Like the block above
-    // this must never abort start() before map.js is re-injected.
     try {
-      // Request persistend storage
-      await this.client.storageRequestPersist();
+      await this.withTimeout(
+        (async () => {
+          // Request persistend storage
+          await this.client.storageRequestPersist();
 
-      // Load user data
-      await this.loadUserData();
+          // Login client from map data
+          this.client.loginFromMap();
 
-      // Fix alt map sdk if needed
-      this.fixAltMapSdk();
+          // Load user data
+          await this.loadUserData();
+        })(),
+        5000,
+        "FMG user data loading"
+      );
     } catch (err) {
-      logger.error("Failed to load user map data, loading map anyway.", err);
+      logger.error("Failed to load FMG user data, loading map anyway.", err);
     }
 
-    // Pin the pro flags right before map.js boots, so its boot-time re-sync
-    // (GET /api/v1/user/map-data/{mapId}) can't flip hasPro back to false and
-    // re-lock the free-user cap. Without this, map.js treats the user as free
-    // and stops sending mark/track requests, so nothing gets saved.
-    this.lockProUnlock();
+    // Fix alt map sdk if needed
+    this.fixAltMapSdk();
 
-    // Answer map.js's boot re-sync (GET /api/v1/user/map-data/{mapId}) at the
-    // XMLHttpRequest layer with FMG's data, so it re-applies our found locations
-    // and pro state instead of the server's free-account data. map.js makes this
-    // request through its own bundled axios rather than window.axios, so the
-    // AxiosInterceptor cannot see it. That is why this hooks at the XHR level.
-    this.client.installMapDataResyncInterceptor();
+    this.lockProData();
 
-    await activateBlockedMapgenieScript("map");
+    await this.activateMapScript();
+    await this.installRequestInterceptor();
+    await this.syncSavedLocationsToMap();
 
     this.setupEventListeners();
-    await this.client.installInterceptor();
     await this.ui.mount();
 
     // Restore fmgMapId param on pro maps

--- a/src/contexts/page/pages/map/mapInfo.ts
+++ b/src/contexts/page/pages/map/mapInfo.ts
@@ -1,0 +1,15 @@
+import { LazyGetter } from "lazy-get-decorator";
+
+export class MapInfo {
+  @LazyGetter({ select: (v) => v !== 0 })
+  public static get totalMarkerLocations() {
+    if (!window.mapData) {
+      return 0;
+    }
+    return window.mapData.locations.filter(
+      (l) =>
+        l.category.display_type === "marker" ||
+        l.category.display_type === "text|marker"
+    ).length;
+  }
+}

--- a/src/contexts/page/pages/map/ui/TotalProgress/TotalProgress.tsx
+++ b/src/contexts/page/pages/map/ui/TotalProgress/TotalProgress.tsx
@@ -1,0 +1,66 @@
+import { IntegratedComponent } from "@/common/ui/integrated";
+import { MapInfo } from "../../mapInfo";
+
+export class TotalProgress extends IntegratedComponent<TotalProgress.Props> {
+  constructor(props?: TotalProgress.Props) {
+    super(props ?? { total: 0, found: 0 });
+  }
+
+  public render() {
+    const { total, found } = this.props;
+
+    const percent = total > 0 ? (found / total) * 100 : 100;
+
+    return (
+      <>
+        <div
+          className="progress-item-wrapper"
+          style={{
+            marginRight: "10px",
+            background: "transparent",
+          }}
+        >
+          <div className="progress-item" style={{ cursor: "default" }}>
+            <span className="title">{percent.toFixed(2) + "%"}</span>
+            <span className="counter">
+              {found} / {total}
+            </span>
+            <div className="progress-bar-container">
+              <div
+                className="progress-bar"
+                role="progressbar"
+                style={{ width: percent + "%" }}
+              ></div>
+            </div>
+          </div>
+        </div>
+        <hr />
+      </>
+    );
+  }
+
+  public shouldUpdate(nextProps: TotalProgress.Props) {
+    return (
+      this.props.total !== nextProps.total ||
+      this.props.found !== nextProps.found
+    );
+  }
+
+  public async mount() {
+    await super.mount(".category-progress", "before");
+  }
+
+  public updateFromState(state: MG.State) {
+    const total = MapInfo.totalMarkerLocations;
+    const found = state.user.foundLocationsCount;
+
+    this.update({ total, found });
+  }
+}
+
+namespace TotalProgress {
+  export interface Props {
+    total: number;
+    found: number;
+  }
+}

--- a/src/contexts/page/pages/map/ui/TotalProgress/index.ts
+++ b/src/contexts/page/pages/map/ui/TotalProgress/index.ts
@@ -1,0 +1,1 @@
+export * from "./TotalProgress";

--- a/src/services/mapgenie.service.ts
+++ b/src/services/mapgenie.service.ts
@@ -43,6 +43,16 @@ class MapgenieService {
   }
 
   @Memoize()
+  public async fetchGameInfo(gameId: number | string) {
+    const games = await this.fetchGames();
+    const game = games.find((g) => String(g.id) === String(gameId));
+    if (!game) {
+      throw new Error(`Game with id "${gameId}" not found`);
+    }
+    return game;
+  }
+
+  @Memoize()
   public async fetchGame(gameId: number | string) {
     const { data } = await this.axios.get<MG.Api.GameFull>(
       `/games/${gameId}/full`


### PR DESCRIPTION
MapGenie.io updated their site (June 2026), breaking the extension boot flow — black screen, map not loading, components not showing.

Key fixes (ported from [NR2BJ/free-map-genie v3.0.6](https://github.com/NR2BJ/free-map-genie)):

### Background rules
- `urlFilter` → `regexFilter` for reliable declarativeNetRequest matching
- Disable existing rules before enabling to ensure clean state

### Script loading (`activateBlockedMapgenieScript`)
- String replace → proper `URL` API for `ready` parameter injection
- jQuery → native DOM
- Promise-based loading with load/error events

### Map page boot flow (`MapPage.start()`)
- `withTimeout()` wrapper on all async operations — prevents hanging
- `lockProData()` — locks pro-required properties (`isPro`, `hasPro`, `maxMarkedLocations`) via `Object.defineProperty` so MapGenie cannot overwrite them
- `filterTrackedCategoriesForCurrentMap()` — removes category IDs not present on current map (would crash map init)
- `syncSavedLocationsToMap()` — restores saved FMG markers after map script loads
- `loadRemoteMapData()` — graceful degradation when pro map API is unavailable
- Error handling throughout — map loads even when FMG data operations fail

### Page detection
- `www.mapgenie.io` subdomain support
- `hasMapgenieMeta()` fallback via meta/link tags

### Links
- `isLockedMapLink()` — robust locked link detection
- `getFreeLinkUrl()` — fallback free map URL resolution

### Other
- `fetchGameInfo()` added to MapgenieService
- Tile coordinate swap support in map data loader
- `MapgenieAdBlocker.remove()` → `start()` rename
- Type definitions updated (`MapTypeControl`, `MapType`, `setFoundLocationsShown`)

Closes #103, closes #110, closes #111

Build verified: `wxt build` → zero errors, 3.7 MB